### PR TITLE
Build filename from final model URL path if Content-Disposition not present

### DIFF
--- a/app/src/main/java/com/ammar/wallflow/Constants.kt
+++ b/app/src/main/java/com/ammar/wallflow/Constants.kt
@@ -39,7 +39,7 @@ const val EFFICIENT_DET_LITE_0_MODEL_NAME = "EfficientDet-Lite0"
 const val EFFICIENT_DET_LITE_0_MODEL_URL = "https://tfhub.dev/tensorflow/lite-model/" +
     "efficientdet/lite0/detection/metadata/1?lite-format=tflite"
 const val EFFICIENT_DET_LITE_0_MODEL_FILE_NAME =
-    "lite-model_efficientdet_lite0_detection_metadata_1.tflite"
+    "kagglesdsdata_models_992_1146_1.tflite"
 
 val INTERNAL_MODELS = listOf(
     EFFICIENT_DET_LITE_0_MODEL_NAME,

--- a/app/src/main/java/com/ammar/wallflow/workers/Helpers.kt
+++ b/app/src/main/java/com/ammar/wallflow/workers/Helpers.kt
@@ -70,11 +70,13 @@ private fun createFile(
         else -> {
             val contentDispositionStr = response.header("Content-Disposition")
             val parseExceptionMsg = "Could not parse file name from response"
-            if (contentDispositionStr.isNullOrEmpty()) {
-                throw IllegalArgumentException(parseExceptionMsg)
+            val pathFileName = response.request.url.pathSegments.joinToString("_");
+            if (!contentDispositionStr.isNullOrEmpty()) {
+                ContentDisposition.parse(contentDispositionStr).filename
+                    ?: throw IllegalArgumentException(parseExceptionMsg)
+            } else {
+                pathFileName
             }
-            ContentDisposition.parse(contentDispositionStr).filename
-                ?: throw IllegalArgumentException(parseExceptionMsg)
         }
     }
     return createFile(dir, fName)


### PR DESCRIPTION
fixes  #65
I got this working, however I can't seem to figure out why the 'default' model of EfficientDet-Lite0 keeps getting downloaded
It works fine for custom models but this may need some modification (done java before, but kotlin + android is a first for me so feel free to modify or do your own implementation as you wish)

The final url for the default model is https://storage.googleapis.com/kagglesdsdata/models/992/1146/1.tflite
I didn't really want to just use the filename as it seems like all models are stored in the same folder. The entire path string should be unique though so opted for that - assuming people will still be trying to use the tfhub.dev urls